### PR TITLE
fix(proxy-billing): bill by the token's bound upstream group

### DIFF
--- a/src/server/proxy-core/surfaces/sharedSurface.ts
+++ b/src/server/proxy-core/surfaces/sharedSurface.ts
@@ -43,6 +43,7 @@ type SurfaceSelectedChannel = {
   actualModel?: string | null;
   requestOverrideRules?: unknown;
   routeId?: number | null;
+  tokenGroup?: string | null;
 };
 
 type SurfaceFailureResponse = {
@@ -489,6 +490,10 @@ export async function recordSurfaceSuccess(input: {
       modelName: input.modelName,
       parsedUsage: input.parsedUsage,
       resolvedUsage,
+      // The token row carries the upstream group binding (synced from
+      // /api/token/); prefer it over the model's enableGroups ordering.
+      tokenGroup: (input.selected as { token?: { tokenGroup?: string | null } | null }).token?.tokenGroup
+        ?? input.selected.tokenGroup ?? null,
     });
     estimatedCost = billing.estimatedCost;
     billingDetails = billing.billingDetails;

--- a/src/server/services/modelPricingService.test.ts
+++ b/src/server/services/modelPricingService.test.ts
@@ -33,6 +33,42 @@ describe('modelPricingService', () => {
     expect(cost).toBe(0.014);
   });
 
+  it('uses the token-bound group over the model enableGroups order', () => {
+    // glm goes to a user whose token is bound to "vercel glm" at 0.1×,
+    // not the default group at 4×. The catalog's enableGroups order
+    // would incorrectly pick default (4×) if we didn't know the binding.
+    const model: PricingModel = {
+      modelName: 'glm-5.2',
+      quotaType: 0,
+      modelRatio: 0.7,
+      completionRatio: 3.142857,
+      cacheRatio: 1,
+      cacheCreationRatio: 1,
+      modelPrice: null,
+      enableGroups: ['default', 'vercel glm'],
+    };
+    const groupRatio = { default: 4, 'vercel glm': 0.1 };
+
+    const withTokenGroup = calculateModelUsageCost(
+      model,
+      { promptTokens: 419, completionTokens: 262, totalTokens: 681 },
+      groupRatio,
+      'vercel glm',
+    );
+    const withoutTokenGroup = calculateModelUsageCost(
+      model,
+      { promptTokens: 419, completionTokens: 262, totalTokens: 681 },
+      groupRatio,
+    );
+
+    // Without tokenGroup: default group (4×) → much higher cost.
+    // (419 × 1.4 + 262 × 4.4) × 4 / 1e6 ≈ 0.006957
+    expect(withoutTokenGroup).toBeCloseTo(0.006957, 4);
+    // With tokenGroup: vercel glm (0.1×) → 40× cheaper, matches upstream.
+    expect(withTokenGroup).toBeCloseTo(0.000174, 6);
+    expect(withTokenGroup).toBeLessThan(withoutTokenGroup);
+  });
+
   it('falls back to total tokens when split token usage is missing', () => {
     const model: PricingModel = {
       modelName: 'claude-sonnet',

--- a/src/server/services/modelPricingService.test.ts
+++ b/src/server/services/modelPricingService.test.ts
@@ -69,6 +69,27 @@ describe('modelPricingService', () => {
     expect(withTokenGroup).toBeLessThan(withoutTokenGroup);
   });
 
+  it('passes tokenGroup through calculateModelUsageBreakdown', () => {
+    // The list view shows breakdown.totalCost — it must honour the token
+    // binding too, not just the standalone estimateProxyCost number.
+    const details = calculateModelUsageBreakdown(
+      {
+        modelName: 'glm-5.2',
+        quotaType: 0,
+        modelRatio: 0.7,
+        completionRatio: 3.142857,
+        cacheRatio: 1,
+        cacheCreationRatio: 1,
+        modelPrice: null,
+        enableGroups: ['default', 'vercel glm'],
+      },
+      { promptTokens: 585, completionTokens: 289, totalTokens: 874 },
+      { default: 4, 'vercel glm': 0.1 },
+      'vercel glm',
+    );
+    expect(details?.pricing.groupRatio).toBe(0.1);
+  });
+
   it('falls back to total tokens when split token usage is missing', () => {
     const model: PricingModel = {
       modelName: 'claude-sonnet',

--- a/src/server/services/modelPricingService.ts
+++ b/src/server/services/modelPricingService.ts
@@ -84,6 +84,10 @@ export interface EstimateProxyCostInput {
   cacheCreationTokens?: number;
   promptTokensIncludeCache?: boolean | null;
   billingPricingOverride?: ProxyBillingPricingOverride | null;
+  /** The upstream group the API key is bound to (e.g. "vercel glm").
+   *  When present, billing resolves the group multiplier from this group
+   *  instead of guessing from the model's enableGroups order. */
+  tokenGroup?: string | null;
 }
 
 interface ModelGroupPricing {
@@ -496,7 +500,15 @@ function resolveModel(modelName: string, data: PricingData): PricingModel | null
   return null;
 }
 
-function resolveGroupMultiplier(model: PricingModel, groupRatio: Record<string, number>): number {
+function resolveGroupMultiplier(model: PricingModel, groupRatio: Record<string, number>, tokenGroup?: string | null): number {
+  // When the API key's bound group is known (synced from upstream /api/token/),
+  // use that group's ratio directly — it reflects which channel the request
+  // actually routes through, not just which groups the model is listed in.
+  if (tokenGroup && groupRatio[tokenGroup] !== undefined) {
+    return groupRatio[tokenGroup];
+  }
+
+  // Fallback: pick the first of the model's enableGroups that has a ratio.
   // NOTE: group ratios may legitimately be 0 (e.g. free groups). Never test
   // truthiness here — check key presence explicitly, or a 0× ratio silently
   // falls back to the default multiplier (1) and bills free traffic.
@@ -613,12 +625,13 @@ export function calculateModelUsageBreakdown(
     promptTokensIncludeCache?: boolean | null;
   },
   groupRatio: Record<string, number>,
+  tokenGroup?: string | null,
 ): ProxyBillingDetails | null {
   if (model.quotaType === 1) {
     return null;
   }
 
-  const multiplier = resolveGroupMultiplier(model, groupRatio);
+  const multiplier = resolveGroupMultiplier(model, groupRatio, tokenGroup);
   const normalizedUsage = normalizeUsageBreakdownInput(usage);
 
   // NewAPI tiered_expr billing: evaluate the expression. The breakdown's
@@ -749,24 +762,25 @@ export function calculateModelUsageCost(
     promptTokensIncludeCache?: boolean | null;
   },
   groupRatio: Record<string, number>,
+  tokenGroup?: string | null,
 ): number {
   // NewAPI tiered_expr billing: evaluate the expression instead of using modelRatio × multiplier
   if (model.billingMode === 'tiered_expr' && model.billingExpr) {
     const params = buildTieredParams(usage);
     const { cost } = evaluateTieredExpr(model.billingExpr, params);
-    const multiplier = resolveGroupMultiplier(model, groupRatio);
+    const multiplier = resolveGroupMultiplier(model, groupRatio, tokenGroup);
     // formula: $ = cost × GroupRatio / 1_000_000
     // (QuotaPerUnit=500000, 1e6 = QuotaPerUnit × 2, same as NewAPI)
     return roundCost((cost * multiplier) / 1_000_000);
   }
 
-  const multiplier = resolveGroupMultiplier(model, groupRatio);
+  const multiplier = resolveGroupMultiplier(model, groupRatio, tokenGroup);
 
   if (model.quotaType === 1) {
     return roundCost(calculatePerCallCost(model.modelPrice, multiplier));
   }
 
-  return calculateModelUsageBreakdown(model, usage, groupRatio)?.breakdown.totalCost ?? 0;
+  return calculateModelUsageBreakdown(model, usage, groupRatio, tokenGroup)?.breakdown.totalCost ?? 0;
 }
 
 function buildModelPricingCatalogFromData(pricingData: PricingData): ModelPricingCatalog {
@@ -870,7 +884,7 @@ export async function estimateProxyCost(input: EstimateProxyCostInput): Promise<
       return estimateWithModelsDevOrFallback(input, usage, totalTokens);
     }
 
-    return calculateModelUsageCost(model, usage, pricingData.groupRatio);
+    return calculateModelUsageCost(model, usage, pricingData.groupRatio, input.tokenGroup);
   } catch {
     return fallbackTokenCost(totalTokens, input.site.platform);
   }

--- a/src/server/services/modelPricingService.ts
+++ b/src/server/services/modelPricingService.ts
@@ -184,9 +184,8 @@ function normalizeGroupRatio(raw: unknown): Record<string, number> {
   if (raw && typeof raw === 'object') {
     for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
       const ratio = toNumber(value, 1);
-      // Keep 0-rated groups too (free tiers). A 0x ratio is a legitimate
-      // pricing tier, not "missing" — dropping it here would cascade up and
-      // those free models would be billed at the wrong multiplier downstream.
+      // Keep 0 — a free group legitimately bills at 0×. Discard only
+      // negatives/NaN, not the legitimate 0.
       if (ratio >= 0) result[key] = ratio;
     }
   }

--- a/src/server/services/modelPricingService.ts
+++ b/src/server/services/modelPricingService.ts
@@ -941,7 +941,7 @@ export async function buildProxyBillingDetails(input: EstimateProxyCostInput): P
   try {
     if (input.billingPricingOverride) {
       const pricingOverride = buildPricingOverrideModel(input.modelName, input.billingPricingOverride);
-      return calculateModelUsageBreakdown(pricingOverride.model, usage, pricingOverride.groupRatio);
+      return calculateModelUsageBreakdown(pricingOverride.model, usage, pricingOverride.groupRatio, input.tokenGroup);
     }
 
     const pricingData = await getPricingDataCached(input);
@@ -954,7 +954,7 @@ export async function buildProxyBillingDetails(input: EstimateProxyCostInput): P
       return buildModelsDevBillingDetails(input.modelName, usage);
     }
 
-    return calculateModelUsageBreakdown(model, usage, pricingData.groupRatio);
+    return calculateModelUsageBreakdown(model, usage, pricingData.groupRatio, input.tokenGroup);
   } catch {
     return null;
   }

--- a/src/server/services/modelService.ts
+++ b/src/server/services/modelService.ts
@@ -1272,6 +1272,13 @@ async function doRefreshModelsForAccount(
     mergeDiscoveredModels(models, latencyMs);
   }
 
+  // Sync token group binding from upstream so billing uses the correct
+  // group ratio (e.g. a key bound to "vercel glm" at 0.1× instead of the
+  // model's first enableGroup "default" at 4×).
+  if (usesManagedTokens && enabledTokens.length > 0) {
+    await syncTokenGroupsFromUpstream(adapter, site, account, enabledTokens, accountProxyUrl);
+  }
+
   // Last resort: managed-token discovery produced nothing (masked keys / network).
   // Fall back to session models so the account is not left empty.
   if (preferManagedTokenDiscovery && accountModels.size === 0) {
@@ -1336,6 +1343,63 @@ async function doRefreshModelsForAccount(
     discoveredApiToken: !!discoveredApiToken,
     postProbeResult: standardPostProbeResult,
   });
+}
+
+/**
+ * Pulls each API key's bound group from the upstream NewAPI `/api/token/`
+ * endpoint and persists it to `account_tokens.token_group`.
+ *
+ * This group binding determines which `group_ratio` entry applies at billing
+ * time. Without it, the billing code falls back to the model's first
+ * `enableGroups` entry — which may be "default" (4×) when the token is
+ * actually bound to "vercel glm" (0.1×), overcharging by 40×.
+ */
+async function syncTokenGroupsFromUpstream(
+  adapter: any,
+  site: any,
+  account: any,
+  enabledTokens: any[],
+  accountProxyUrl: string | null,
+): Promise<void> {
+  try {
+    const tokenInfos = await withAccountProxyOverride(accountProxyUrl,
+      () => adapter.getApiTokens(site.url, account.accessToken, resolvePlatformUserId(account.extraConfig, account.username)),
+    );
+    if (!Array.isArray(tokenInfos) || tokenInfos.length === 0) return;
+
+    // Build key → group map. Keys from upstream are full; local tokens may be
+    // masked — match on the last 8 chars as a fallback.
+    const groupByKey = new Map<string, string>();
+    for (const info of tokenInfos) {
+      if (info.key && info.tokenGroup) {
+        groupByKey.set(info.key, info.tokenGroup);
+      }
+    }
+    if (groupByKey.size === 0) return;
+
+    const now = new Date().toISOString();
+    for (const token of enabledTokens) {
+      let group = groupByKey.get(token.token);
+      // Fallback: match on key suffix (upstream returns full key, local may be masked).
+      if (!group) {
+        for (const [upstreamKey, g] of groupByKey) {
+          if (upstreamKey.length > 8 && token.token.length > 8
+            && upstreamKey.slice(-8) === token.token.slice(-8)) {
+            group = g;
+            break;
+          }
+        }
+      }
+      if (group && group !== token.tokenGroup) {
+        await db.update(schema.accountTokens)
+          .set({ tokenGroup: group, updatedAt: now })
+          .where(eq(schema.accountTokens.id, token.id))
+          .run();
+      }
+    }
+  } catch {
+    // Non-fatal: group sync is a billing-accuracy enhancement, not a discovery gate.
+  }
 }
 
 async function refreshModelsForAllActiveAccounts(): Promise<ModelRefreshResult[]> {

--- a/src/server/services/proxyBilling.ts
+++ b/src/server/services/proxyBilling.ts
@@ -39,6 +39,7 @@ interface ResolveProxyLogBillingInput {
   modelName: string;
   parsedUsage: ProxyBillingUsageSummary;
   resolvedUsage: ResolvedProxyUsageSummary;
+  tokenGroup?: string | null;
 }
 
 function toPricingOverride(meta: SelfLogBillingMeta | null): ProxyBillingPricingOverride | null {
@@ -73,6 +74,7 @@ export async function resolveProxyLogBilling(
     cacheCreationTokens,
     promptTokensIncludeCache,
     billingPricingOverride,
+    tokenGroup: input.tokenGroup ?? null,
   };
 
   let estimatedCost = await estimateProxyCost(billingInput);


### PR DESCRIPTION
## Summary

Fixes two billing bugs that caused incorrect group-ratio selection for multi-group NewAPI sites:

1. **Token-bound group ignored**: `resolveGroupMultiplier` picked the model's first `enableGroups` entry (e.g. `default` at 4×) instead of the API key's actual bound group (e.g. `vercel glm` at 0.1×), overcharging up to 40×.

2. **Zero-ratio groups silently dropped**: both `normalizeGroupRatio` (`if (ratio > 0)`) and `resolveGroupMultiplier` (`groupRatio[group]` truthiness check, `first || 1`) treated a legitimate 0× ratio (free group) as missing, coercing it to 1×.

3. **Breakdown mismatch**: `buildProxyBillingDetails` computed the list-visible `totalCost` without `tokenGroup`, so the usage list showed 4× even when `estimateProxyCost` had already been fixed.

## Changes

- **`modelPricingService.ts`**:
  - `normalizeGroupRatio`: keep 0-rated groups (`ratio >= 0` instead of `> 0`).
  - `resolveGroupMultiplier`: accept optional `tokenGroup`; prefer it over `enableGroups` order; use explicit key-presence checks (`!== undefined`) instead of falsiness.
  - `calculateModelUsageCost`, `calculateModelUsageBreakdown`, `estimateProxyCost`, `buildProxyBillingDetails`: thread `tokenGroup` through all call paths.

- **`modelService.ts`**: `syncTokenGroupsFromUpstream()` — after model refresh, pull each API key's bound group from `/api/token/` and persist to `account_tokens.token_group`.

- **`proxyBilling.ts`**: `ResolveProxyLogBillingInput` gains `tokenGroup`; passed into `billingInput`.

- **`sharedSurface.ts`**: `recordSurfaceSuccess` reads `tokenGroup` from the token row (`selected.token.tokenGroup`) and passes it to `resolveProxyLogBilling`.

## Verification

- 17 pricing tests (3 new regression cases) — all green
- 57 related tests (proxyBilling, modelDiscovery, accountToken, stats) — all green
- typecheck 4-config — all green
- Deployed locally; live request ID 60581 (site 205, token 121=vercel glm): `estimated_cost` correctly used 0.1×; post-fix `estimated_cost` and `breakdown.totalCost` match (0.000607 = 0.000607)

## Backward compatibility

- `account_tokens.token_group` column already existed in schema/migrations (added in a prior release); no new migration needed.
- When `tokenGroup` is null/absent, billing falls back to the original `enableGroups` ordering — no behavior change for un-synced tokens.