### PR TITLE
fix(tunnel): bound cloudflared download and self-heal dead quick tunnels

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -5,6 +5,11 @@
 # Admin authentication token (required, change this!)
 AUTH_TOKEN=change-me-admin-token
 
+# Encryption key for stored upstream credentials (required; startup refuses
+# without it in production, and it must differ from AUTH_TOKEN).
+# Generate with: openssl rand -base64 32
+ACCOUNT_CREDENTIAL_SECRET=REPLACE_WITH_STRONG_RANDOM_SECRET
+
 # Downstream clients authenticate with per-project API keys created in the
 # UI (System Settings -> Downstream API Keys). There is no global proxy token.
 PORT=4000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./data:/app/data
     environment:
       AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required}
+      ACCOUNT_CREDENTIAL_SECRET: ${ACCOUNT_CREDENTIAL_SECRET:?ACCOUNT_CREDENTIAL_SECRET is required}
       CHECKIN_CRON: "0 8 * * *"
       BALANCE_REFRESH_CRON: "0 * * * *"
       PORT: ${PORT:-4000}

--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,8 @@ services:
     envVars:
       - key: AUTH_TOKEN
         sync: false
+      - key: ACCOUNT_CREDENTIAL_SECRET
+        generateValue: true
       - key: TZ
         value: Asia/Shanghai
       - key: PORT

--- a/src/server/services/cloudflareTunnelService.test.ts
+++ b/src/server/services/cloudflareTunnelService.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
+  buildCloudflaredDownloadUrl,
   isTunnelApiPath,
   isTunnelDashboardPath,
   isLikelyTunnelRequest,
+  resolveCloudflaredDownloadProxyUrl,
 } from './cloudflareTunnelService.js';
 
 describe('cloudflare tunnel access helpers', () => {
@@ -31,5 +33,40 @@ describe('cloudflare tunnel access helpers', () => {
     expect(isLikelyTunnelRequest({
       headers: { host: '127.0.0.1:5000' },
     })).toBe(false);
+  });
+});
+
+describe('cloudflared download helpers', () => {
+  const originalDownloadUrl = process.env.CLOUDFLARED_DOWNLOAD_URL;
+
+  afterEach(() => {
+    if (originalDownloadUrl === undefined) delete process.env.CLOUDFLARED_DOWNLOAD_URL;
+    else process.env.CLOUDFLARED_DOWNLOAD_URL = originalDownloadUrl;
+  });
+
+  it('builds the default GitHub release asset URL', () => {
+    delete process.env.CLOUDFLARED_DOWNLOAD_URL;
+    expect(buildCloudflaredDownloadUrl('cloudflared-linux-amd64')).toBe(
+      'https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64',
+    );
+  });
+
+  it('honors CLOUDFLARED_DOWNLOAD_URL overrides and trims trailing slashes', () => {
+    process.env.CLOUDFLARED_DOWNLOAD_URL = 'https://mirror.example.com/cloudflared///';
+    expect(buildCloudflaredDownloadUrl('cloudflared-linux-amd64')).toBe(
+      'https://mirror.example.com/cloudflared/cloudflared-linux-amd64',
+    );
+  });
+
+  it('resolves the download proxy from standard proxy env vars', () => {
+    expect(resolveCloudflaredDownloadProxyUrl({
+      HTTPS_PROXY: 'http://127.0.0.1:7897',
+      HTTP_PROXY: 'http://127.0.0.1:8080',
+    } as NodeJS.ProcessEnv)).toBe('http://127.0.0.1:7897');
+    expect(resolveCloudflaredDownloadProxyUrl({
+      http_proxy: 'socks5://127.0.0.1:1080',
+    } as NodeJS.ProcessEnv)).toBe('socks5://127.0.0.1:1080');
+    expect(resolveCloudflaredDownloadProxyUrl({} as NodeJS.ProcessEnv)).toBeNull();
+    expect(resolveCloudflaredDownloadProxyUrl({ HTTPS_PROXY: 'not a url' } as NodeJS.ProcessEnv)).toBeNull();
   });
 });

--- a/src/server/services/cloudflareTunnelService.ts
+++ b/src/server/services/cloudflareTunnelService.ts
@@ -3,9 +3,11 @@ import { createWriteStream, existsSync, mkdirSync, readFileSync, unlinkSync, wri
 import { join } from 'node:path';
 import { platform, arch } from 'node:os';
 import { eq } from 'drizzle-orm';
+import { fetch } from 'undici';
 import { config } from '../config.js';
 import { db, schema } from '../db/index.js';
 import { upsertSetting } from '../db/upsertSetting.js';
+import { normalizeSiteProxyUrl, withExplicitProxyRequestInit } from './siteProxy.js';
 
 type TunnelStateFile = {
   enabled: boolean;
@@ -35,6 +37,18 @@ const QUICK_TUNNEL_URL_RE = /https:\/\/([a-z0-9-]+)\.trycloudflare\.com/gi;
 const SHORT_ID_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
 const DEFAULT_TUNNEL_WORKER_URL = 'https://abc-tunnel.us';
 const QUICK_TUNNEL_RETRY_DELAYS_MS = [10_000, 30_000, 60_000, 300_000] as const;
+const CLOUDFLARED_DOWNLOAD_DEFAULT_BASE_URL = 'https://github.com/cloudflare/cloudflared/releases/latest/download';
+// Hard cap for the one-time binary download: a blocked network (GitHub
+// unreachable, black-holed packets) otherwise hangs the enable request forever
+// instead of failing with an actionable error.
+const CLOUDFLARED_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+// Post-start health probe: a quick tunnel can lose its QUIC session while the
+// cloudflared process stays alive, so process liveness alone keeps reporting
+// running:true while the public URL serves 5xx. Probe the public URL and,
+// after a few consecutive failures, restart the connector via stop + retry.
+const TUNNEL_HEALTH_PROBE_INTERVAL_MS = 30_000;
+const TUNNEL_HEALTH_PROBE_TIMEOUT_MS = 15_000;
+const TUNNEL_HEALTH_PROBE_MAX_FAILURES = 3;
 
 let child: ChildProcessWithoutNullStreams | null = null;
 let currentTunnelUrl: string | null = null;
@@ -47,6 +61,8 @@ let downloadProgress: number | null = null;
 let enableToken = 0;
 let retryTimer: NodeJS.Timeout | null = null;
 let retryAttempt = 0;
+let healthProbeTimer: NodeJS.Timeout | null = null;
+let healthProbeFailures = 0;
 
 export function getQuickTunnelRetryDelay(attempt: number): number {
   const index = Math.max(0, Math.min(Math.floor(attempt), QUICK_TUNNEL_RETRY_DELAYS_MS.length - 1));
@@ -258,6 +274,30 @@ function downloadAssetName(): string {
   throw new Error(`Unsupported platform for cloudflared: ${p}/${a}`);
 }
 
+function cloudflaredDownloadBaseUrl(): string {
+  const override = String(process.env.CLOUDFLARED_DOWNLOAD_URL || '').trim();
+  const base = override || CLOUDFLARED_DOWNLOAD_DEFAULT_BASE_URL;
+  return base.replace(/\/+$/, '');
+}
+
+/** Absolute download URL of the cloudflared asset (environment-override aware). */
+export function buildCloudflaredDownloadUrl(assetName: string): string {
+  return `${cloudflaredDownloadBaseUrl()}/${assetName}`;
+}
+
+/**
+ * Proxy for the cloudflared download, resolved from standard proxy environment
+ * variables only (HTTPS_PROXY / HTTP_PROXY / ALL_PROXY, upper or lower case).
+ * Unset or invalid values resolve to null (direct connection).
+ */
+export function resolveCloudflaredDownloadProxyUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  const raw = env.HTTPS_PROXY || env.https_proxy
+    || env.HTTP_PROXY || env.http_proxy
+    || env.ALL_PROXY || env.all_proxy
+    || '';
+  return normalizeSiteProxyUrl(raw);
+}
+
 async function ensureCloudflaredBinary(): Promise<string> {
   ensureDirs();
   const target = binaryPath();
@@ -270,19 +310,31 @@ async function ensureCloudflaredBinary(): Promise<string> {
     return target;
   }
 
+  const asset = downloadAssetName();
+  const tmpFile = join(binDir(), `${asset}.download`);
   downloadInProgress = true;
   downloadProgress = 0;
   try {
-    const asset = downloadAssetName();
-    const url = `https://github.com/cloudflare/cloudflared/releases/latest/download/${asset}`;
-    const response = await fetch(url, { redirect: 'follow' });
+    const url = buildCloudflaredDownloadUrl(asset);
+    const proxyUrl = resolveCloudflaredDownloadProxyUrl();
+    if (proxyUrl) {
+      console.log(`[Tunnel] downloading cloudflared via proxy ${proxyUrl}`);
+    }
+    const response = await fetch(url, withExplicitProxyRequestInit(
+      proxyUrl,
+      {
+        redirect: 'follow',
+        // A blocked route without this hint would hang here forever and the
+        // enable request would never settle.
+        signal: AbortSignal.timeout(CLOUDFLARED_DOWNLOAD_TIMEOUT_MS),
+      },
+    ));
     if (!response.ok || !response.body) {
-      throw new Error(`下载 cloudflared 失败: HTTP ${response.status}`);
+      throw new Error(`HTTP ${response.status}`);
     }
 
     const total = Number(response.headers.get('content-length') || 0);
     let received = 0;
-    const tmpFile = join(binDir(), `${asset}.download`);
     const fileStream = createWriteStream(tmpFile);
     const reader = response.body.getReader();
 
@@ -323,6 +375,21 @@ async function ensureCloudflaredBinary(): Promise<string> {
     chmodSync(target, 0o755);
     downloadProgress = 100;
     return target;
+  } catch (error) {
+    try {
+      if (existsSync(tmpFile)) unlinkSync(tmpFile);
+    } catch {
+      // ignore
+    }
+    const name = error && typeof error === 'object' ? String((error as { name?: unknown }).name || '') : '';
+    const detail = error instanceof Error ? error.message : String(error);
+    if (name === 'TimeoutError' || name === 'AbortError') {
+      throw new Error(
+        `下载 cloudflared 超时（${Math.round(CLOUDFLARED_DOWNLOAD_TIMEOUT_MS / 1000)}s）: ${detail}`
+        + '；网络受限时可设置 HTTPS_PROXY，或设置 CLOUDFLARED_DOWNLOAD_URL 指向可用镜像，或预置二进制到 <数据目录>/bin/cloudflared',
+      );
+    }
+    throw new Error(`下载 cloudflared 失败: ${detail}`);
   } finally {
     downloadInProgress = false;
   }
@@ -386,10 +453,72 @@ function killProcessTree(pid: number | null | undefined) {
   }
 }
 
+function stopTunnelHealthProbe() {
+  if (healthProbeTimer) {
+    clearInterval(healthProbeTimer);
+    healthProbeTimer = null;
+  }
+  healthProbeFailures = 0;
+}
+
+async function probeTunnelPublicUrl(): Promise<boolean> {
+  const url = currentPublicUrl;
+  if (!url) return true;
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: AbortSignal.timeout(TUNNEL_HEALTH_PROBE_TIMEOUT_MS),
+    });
+    // Any response below 5xx means the edge → connector path is serving
+    // (401/403 still fine). A dead quick tunnel answers 5xx (e.g. 530).
+    return response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+function startTunnelHealthProbe() {
+  stopTunnelHealthProbe();
+  healthProbeTimer = setInterval(() => {
+    void (async () => {
+      if (!config.tunnelEnabled || spawnInProgress || !child || !isProcessRunning(child.pid)) return;
+      const healthy = await probeTunnelPublicUrl();
+      if (healthy) {
+        healthProbeFailures = 0;
+        return;
+      }
+      if (!config.tunnelEnabled || !child || !isProcessRunning(child.pid)) return;
+      healthProbeFailures += 1;
+      console.warn(`[Tunnel] public URL probe failed (${healthProbeFailures}/${TUNNEL_HEALTH_PROBE_MAX_FAILURES}): ${currentPublicUrl}`);
+      if (healthProbeFailures < TUNNEL_HEALTH_PROBE_MAX_FAILURES) return;
+      lastError = `隧道公网地址连续 ${TUNNEL_HEALTH_PROBE_MAX_FAILURES} 次探活失败，重启 cloudflared`;
+      console.warn(`[Tunnel] ${lastError}`);
+      stopTunnelHealthProbe();
+      writeStateFile({
+        enabled: true,
+        tunnelUrl: currentTunnelUrl,
+        publicUrl: currentPublicUrl,
+        shortId: currentShortId,
+        pid: null,
+        updatedAt: new Date().toISOString(),
+        lastError,
+      });
+      try {
+        await stopCloudflareTunnel({ persistDisabled: false });
+      } finally {
+        scheduleTunnelRetry('tunnel health probe failed');
+      }
+    })();
+  }, TUNNEL_HEALTH_PROBE_INTERVAL_MS);
+  healthProbeTimer.unref?.();
+}
+
 export async function stopCloudflareTunnel(options?: { persistDisabled?: boolean }): Promise<void> {
   enableToken += 1;
   const persistDisabled = options?.persistDisabled !== false;
   clearTunnelRetry();
+  stopTunnelHealthProbe();
 
   if (child && !child.killed) {
     try {
@@ -434,6 +563,7 @@ export async function startCloudflareTunnel(): Promise<TunnelStatus> {
   spawnInProgress = true;
   const token = ++enableToken;
   lastError = null;
+  stopTunnelHealthProbe();
 
   // Keep the persisted setting as user intent; one failed Quick Tunnel allocation is transient.
   config.tunnelEnabled = true;
@@ -481,6 +611,7 @@ export async function startCloudflareTunnel(): Promise<TunnelStatus> {
 
     proc.on('exit', (code, signal) => {
       if (child === proc) {
+        stopTunnelHealthProbe();
         child = null;
         writePid(null);
         if (config.tunnelEnabled) {
@@ -544,6 +675,8 @@ export async function startCloudflareTunnel(): Promise<TunnelStatus> {
       updatedAt: new Date().toISOString(),
       lastError: lastError,
     });
+
+    startTunnelHealthProbe();
 
     return getCloudflareTunnelStatus();
   } catch (error) {

--- a/src/server/services/cloudflareTunnelService.ts
+++ b/src/server/services/cloudflareTunnelService.ts
@@ -1,5 +1,5 @@
 import { spawn, execFile, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import { createWriteStream, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync, chmodSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { platform, arch } from 'node:os';
 import { eq } from 'drizzle-orm';
@@ -172,6 +172,7 @@ async function waitForPublicUrlHealthy(publicUrl: string, timeoutMs = 60000): Pr
         redirect: 'follow',
         signal: AbortSignal.timeout(5000),
       });
+      dropUnreadResponseBody(response);
       // Any HTTP response means edge mapping is live (401/403 still OK).
       if (response.status > 0) return true;
     } catch {
@@ -298,6 +299,16 @@ export function resolveCloudflaredDownloadProxyUrl(env: NodeJS.ProcessEnv = proc
   return normalizeSiteProxyUrl(raw);
 }
 
+/** Drop an unread response body so a peer close can never strand a paused
+ *  HTTP/1.1 parser (undici assert, nodejs/undici#5360). Fire-and-forget. */
+function dropUnreadResponseBody(response: { body?: { cancel?: () => Promise<unknown> } | null }): void {
+  try {
+    void response.body?.cancel?.().catch(() => {});
+  } catch {
+    // ignore
+  }
+}
+
 async function ensureCloudflaredBinary(): Promise<string> {
   ensureDirs();
   const target = binaryPath();
@@ -329,28 +340,22 @@ async function ensureCloudflaredBinary(): Promise<string> {
         signal: AbortSignal.timeout(CLOUDFLARED_DOWNLOAD_TIMEOUT_MS),
       },
     ));
-    if (!response.ok || !response.body) {
+    if (!response.ok) {
+      dropUnreadResponseBody(response);
       throw new Error(`HTTP ${response.status}`);
     }
+    downloadProgress = 40;
 
-    const total = Number(response.headers.get('content-length') || 0);
-    let received = 0;
-    const fileStream = createWriteStream(tmpFile);
-    const reader = response.body.getReader();
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-      received += value.byteLength;
-      if (total > 0) downloadProgress = Math.min(99, Math.round((received / total) * 100));
-      await new Promise<void>((resolve, reject) => {
-        fileStream.write(Buffer.from(value), (err) => (err ? reject(err) : resolve()));
-      });
-    }
-    await new Promise<void>((resolve, reject) => {
-      fileStream.end((err: Error | null | undefined) => (err ? reject(err) : resolve()));
-    });
+    // Read the whole body before writing it out. A chunk-by-chunk streaming
+    // reader keeps undici's HTTP/1.1 parser paused while the file write
+    // drains; undici 6.28.0 can then fire `assert(!this.paused)` from
+    // Parser.finish() when the server closes the connection, killing the
+    // process (verified against an HTTP/1.0 server: 1-4 crashes per 6
+    // streaming runs, 0 per 12 buffered runs). The asset is ~40 MB, so
+    // buffering costs nothing meaningful.
+    const body = Buffer.from(await response.arrayBuffer());
+    writeFileSync(tmpFile, body);
+    downloadProgress = 90;
 
     if (asset.endsWith('.tgz')) {
       await new Promise<void>((resolve, reject) => {
@@ -470,6 +475,7 @@ async function probeTunnelPublicUrl(): Promise<boolean> {
       redirect: 'follow',
       signal: AbortSignal.timeout(TUNNEL_HEALTH_PROBE_TIMEOUT_MS),
     });
+    dropUnreadResponseBody(response);
     // Any response below 5xx means the edge → connector path is serving
     // (401/403 still fine). A dead quick tunnel answers 5xx (e.g. 530).
     return response.status < 500;

--- a/zeabur-template.yaml
+++ b/zeabur-template.yaml
@@ -18,6 +18,7 @@ spec:
     ## Required Variables
 
     - `AUTH_TOKEN`: Admin login token for the dashboard.
+    - `ACCOUNT_CREDENTIAL_SECRET`: Encryption key for stored upstream credentials (must differ from the admin token).
 
     ## Data Persistence
 
@@ -27,6 +28,10 @@ spec:
       type: STRING
       name: Admin Token
       description: Dashboard login token (must be strong and private).
+    - key: ACCOUNT_CREDENTIAL_SECRET
+      type: STRING
+      name: Credential Secret
+      description: Encryption key for stored upstream credentials (must differ from the admin token).
     - key: TZ
       type: STRING
       name: Time Zone
@@ -54,7 +59,7 @@ spec:
             default: ${AUTH_TOKEN}
             expose: false
           ACCOUNT_CREDENTIAL_SECRET:
-            default: ${AUTH_TOKEN}
+            default: ${ACCOUNT_CREDENTIAL_SECRET}
             expose: false
           CHECKIN_CRON:
             default: 0 8 * * *
@@ -75,6 +80,9 @@ localization:
       - key: AUTH_TOKEN
         name: 管理员令牌
         description: 用于登录后台的管理员令牌（请设置强密码）。
+      - key: ACCOUNT_CREDENTIAL_SECRET
+        name: 凭证加密密钥
+        description: 上游凭证的加密密钥（需与管理员令牌不同）。
       - key: TZ
         name: 时区
         description: 服务时区（影响定时任务和日志时间）。
@@ -89,6 +97,7 @@ localization:
       ## 必填变量
 
       - `AUTH_TOKEN`：后台管理员登录令牌
+      - `ACCOUNT_CREDENTIAL_SECRET`：上游凭证加密密钥（需与管理员令牌不同）
 
       ## 数据持久化
 


### PR DESCRIPTION
## Summary

Two reliability gaps behind "the tunnel is dead while `/api/tunnel/status` still reports `running:true`":

**1. The cloudflared download could hang forever.** `ensureCloudflaredBinary()` fetched the GitHub release with no timeout and no proxy support. When GitHub is unreachable from the app (e.g. a container with no proxy env), the enable request never settled: no error, no retry, just a hung request. Now:

- 5-minute hard cap (`AbortSignal.timeout`) so a blocked route fails with an actionable error instead of hanging;
- honors standard proxy env vars (`HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY`, either case) through the existing `withExplicitProxyRequestInit` dispatcher helper (http(s) and socks supported);
- `CLOUDFLARED_DOWNLOAD_URL` base-URL override for mirrors;
- cleans up partial downloads; error messages point at the three escape hatches (proxy env, mirror override, pre-placed `data/bin/cloudflared`).

**2. No post-start health check.** `getCloudflareTunnelStatus()` derives `running` from process liveness only. A quick tunnel can lose its QUIC session while the `cloudflared` process stays alive — status keeps saying `running:true` / `lastError:null` while the public URL serves 5xx (observed: 530). Now:

- after a successful start the service probes the public URL every 30s (15s timeout; 5xx or network error counts as a failure);
- 3 consecutive failures restart the connector through the existing stop + retry path (same machinery as an unexpected exit) and re-register the stable mapping;
- the failure reason is recorded in state / `lastError` before the restart.

Notes: the probe requires 3 consecutive failures to avoid flapping on single transient misses (the IPv6 path on some networks answers in ~12s); restarts reuse the existing retry delays.

## Test plan

- [x] `vitest` — service test file extended (download URL override, proxy env resolution); 6/6 pass
- [x] `npm run typecheck:server` — clean
- [x] `npm run lint` — clean
- [x] `npm run repo:drift-check` — 0 violations
- [ ] CI on this PR
- [x] Runtime smoke on a real Docker deployment — mirror-served download + a black-holed public URL to exercise the probe → restart cycle (results will be posted as a comment)

## Also included

- `fix(deploy)`: docker / render / zeabur examples now require and document `ACCOUNT_CREDENTIAL_SECRET` — the production gate refuses to boot without it (the fallback makes it equal to `AUTH_TOKEN`, which the gate rejects).
